### PR TITLE
Update index.html

### DIFF
--- a/guides/epub-aria-authoring/index.html
+++ b/guides/epub-aria-authoring/index.html
@@ -158,7 +158,7 @@
 				<p>or else a list role needs to be applied to an element that encloses all the note:</p>
 				
 				<pre>&lt;div role="list"&gt;
-   &lt;p role="doc-biblioentry">&#8230;&lt;/li>
+   &lt;p role="doc-biblioentry">&#8230;&lt;/p>
    &#8230;
 &lt;/div></pre>
 			</section>


### PR DESCRIPTION
typo within example about role="list" where a p is closed with an &lt;/li> on line 161